### PR TITLE
Ruby 1.9.2 compatibility

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,13 @@
+[2011/01/27]
+* Version 2.1
+    - Ian Marlier <imarlier@brightcove.com>: Make ruby-shadow compile under Ruby 1.9.2
+        * STR2CSTR macro was removed in Ruby 1.9.2, after being deprecated in Ruby 1.8.  Change
+          to StringValuePtr() in its place.
+
+[2010/07/27]
+* Version 2.0
+    - Adam Palmblad <>: Make ruby-shadow compile under Ruby 1.9
+
 [1999/08/18]
 * version 1.4.1
   - extconf.rb supports glibc2(libc6).

--- a/shadow.c
+++ b/shadow.c
@@ -55,7 +55,7 @@ rb_shadow_sgetspent(VALUE self, VALUE str)
   if( TYPE(str) != T_STRING )
     rb_raise(rb_eException,"argument must be a string.");
 
-  entry = sgetspent(STR2CSTR(str));
+  entry = sgetspent(StringValuePtr(str));
 
   if( entry == NULL )
     return Qnil;
@@ -137,7 +137,7 @@ rb_shadow_getspnam(VALUE self, VALUE name)
   if( TYPE(name) != T_STRING )
     rb_raise(rb_eException,"argument must be a string.");
 
-  entry = getspnam(STR2CSTR(name));
+  entry = getspnam(StringValuePtr(name));
 
   if( entry == NULL )
     return Qnil;
@@ -170,8 +170,8 @@ rb_shadow_putspent(VALUE self, VALUE entry, VALUE file)
     val[i] = RSTRUCT_PTR( entry )[i]; //val[i] = RSTRUCT(entry)->ptr[i];
   cfile = file_pr( RFILE(file)->fptr );
 
-  centry.sp_namp = STR2CSTR(val[0]);
-  centry.sp_pwdp = STR2CSTR(val[1]);
+  centry.sp_namp = StringValuePtr(val[0]);
+  centry.sp_pwdp = StringValuePtr(val[1]);
   centry.sp_lstchg = FIX2INT(val[2]);
   centry.sp_min = FIX2INT(val[3]);
   centry.sp_max = FIX2INT(val[4]);


### PR DESCRIPTION
Ruby 1.9.2 removed the STR2CSTR macro (deprecated, but still available, from Ruby 1.8.0 through Ruby 1.9.1).  This replaces the use of that macro in shadow.c with StringValuePtr().

Also updated the history file to reflect the changes that have been made to cause the module to work under Ruby 1.9.
