### PR TITLE
Ruby18

### DIFF
--- a/depend
+++ b/depend
@@ -1,7 +1,9 @@
 ifneq (,$(findstring 1.9,$(ruby_version)))
 	io_lib=$(hdrdir)/ruby/ruby/io.h
+	hdr=$(hdrdir)/ruby/ruby.h
 else
 	io_lib=$(hdrdir)/ruby/rubyio.h
+	hdr=$(hdrdir)/ruby.h
 endif
 	
-shadow.o: shadow.c $(hdrdir)/ruby/ruby.h $(io_lib)
+shadow.o: shadow.c $(hdr) $(io_lib)


### PR DESCRIPTION
Looks like there was a minor bug in compiling against ruby 1.8. Fixing the ruby header path made it work for me.
