### PR TITLE
Add license to include OR public domain, split out

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,5 @@
+License: Free for any use with your own risk!
+
+OR
+
+The terms of the Public Domain License (http://creativecommons.org/licenses/publicdomain/)

--- a/README
+++ b/README
@@ -2,7 +2,7 @@ Shadow Password module
 
 Copyright (C) 1998-1999 Takaaki Tateishi <ttate@jaist.ac.jp>
 Modified at: <1999/8/19 06:47:14 by ttate>
-License: Free for any use with your own risk!
+License: See LICENSE
 
 
 1. What's this


### PR DESCRIPTION
This commit splits the License portion of the README out into a separate file,
and adds an OR clause specifying that the Public Domain license is also
acceptable. This allows a more explicit license statement that keeps with the
spirit of the original statement of license for those who find this facilitates
their use of the work.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
