### PR TITLE
Fix segfault on ruby >=1.9 when calling putspent

### DIFF
--- a/shadow.c
+++ b/shadow.c
@@ -17,7 +17,7 @@
 #endif
 
 #ifdef RUBY19
-#define file_ptr(x) (x)->stdio_file
+#define file_ptr(x) rb_io_stdio_file(x)
 #else
 #define file_ptr(x) (x)->f
 #endif


### PR DESCRIPTION
When calling `putspent` or `fgetspent` on linux we'd get a core dump. Using the function `rb_io_stdio_file` to grab the stdio file handle instead of directly using the `stdio_file` member fixed the problem.
