### PR TITLE
Remove the sgetspent method from the pwd impl.

### DIFF
--- a/README
+++ b/README
@@ -34,7 +34,7 @@ ____________________________________________________________
  setspent               |   *   |    *    |   *   |    *
  endspent               |   *   |    *    |   *   |    *
  fgetspent(file)        |   *   |    *    |   N   |    N
- sgetspent(str)         |   *   |    N    |   *   |    *
+ sgetspent(str)         |   *   |    N    |   N   |    N
  putspent(entry,file)   |   *   |    *    |   N   |    N
  lckpwdf,lock           |   *   |    *    |   N   |    N
  ulckpwdf,unlock        |   *   |    *    |   N   |    N

--- a/pwd/shadow.c
+++ b/pwd/shadow.c
@@ -69,26 +69,6 @@ static VALUE convert_pw_struct( struct passwd *entry )
 }
 
 static VALUE
-rb_shadow_sgetspent(VALUE self, VALUE str)
-{
-  PWTYPE *entry;
-  VALUE result;
-
-  if( TYPE(str) != T_STRING )
-    rb_raise(rb_eException, "argument must be a string.");
-
-  entry = getpwnam(StringValuePtr(str));
-
-  if( entry == NULL )
-    return Qnil;
-
-  result = convert_pw_struct( entry );
-
-  free(entry);
-  return result;
-}
-
-static VALUE
 rb_shadow_getspent(VALUE self)
 {
   PWTYPE *entry;
@@ -140,7 +120,6 @@ Init_shadow()
 
   rb_define_module_function(rb_mPasswd,"setspent",rb_shadow_setspent,0);
   rb_define_module_function(rb_mPasswd,"endspent",rb_shadow_endspent,0);
-  rb_define_module_function(rb_mPasswd,"sgetspent",rb_shadow_sgetspent,1);
   rb_define_module_function(rb_mPasswd,"getspent",rb_shadow_getspent,0);
   rb_define_module_function(rb_mPasswd,"getspnam",rb_shadow_getspnam,1);
 }


### PR DESCRIPTION
FreeBSD and OS X do not implement an equivalent to sgetspent, and the
implementation included before did not work as expected.

sgetspent is supposed to parse shadow user data in a string and return the first
entry. The implementation we had called getpwnam, with the
supplied string. This meant it was trying to find a user with a name equal to the
passed in shadow user data.

I tested the current implementation to see if there was some hidden functionality of getpwnam
that allowed it to parse it's input as shadow user data rather than just a name, but it just returns
null if you pass it anything that isn't the name of a user in the system

it's best to just remove the function all together.
