### PR TITLE
Add OpenBSD support

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,7 @@ License: See LICENSE
 
 This module provides tools to read, and, on Linux, append, information related to password files.
 
-Recent versions work on both Linux, Solaris, OS X and FreeBSD.
+Recent versions work on both Linux, Solaris, OS X, FreeBSD and OpenBSD.
 The functions found are translated to their equivalents in libshadow.
 
 Note 
@@ -26,19 +26,19 @@ make # use gmake on FreeBSD
  still present, but no promises about earlier versions of Ruby.
 
 3. Shadow::Passwd module's methods
-____________________________________________________________
- Method                 | Linux | Solaris | OS X  | FreeBSD
-____________________________________________________________
- getspent               |   *   |    *    |   *   |    *
- getspnam(name)         |   *   |    *    |   *   |    *
- setspent               |   *   |    *    |   *   |    *
- endspent               |   *   |    *    |   *   |    *
- fgetspent(file)        |   *   |    *    |   N   |    N
- sgetspent(str)         |   *   |    N    |   N   |    N
- putspent(entry,file)   |   *   |    *    |   N   |    N
- lckpwdf,lock           |   *   |    *    |   N   |    N
- ulckpwdf,unlock        |   *   |    *    |   N   |    N
- lock?                  |   *   |    *    |   N   |    N
+______________________________________________________________________
+ Method                 | Linux | Solaris | OS X  | FreeBSD | OpenBSD
+______________________________________________________________________
+ getspent               |   *   |    *    |   *   |    *    |    *
+ getspnam(name)         |   *   |    *    |   *   |    *    |    *
+ setspent               |   *   |    *    |   *   |    *    |    *
+ endspent               |   *   |    *    |   *   |    *    |    *
+ fgetspent(file)        |   *   |    *    |   N   |    N    |    N
+ sgetspent(str)         |   *   |    N    |   N   |    N    |    N
+ putspent(entry,file)   |   *   |    *    |   N   |    N    |    N
+ lckpwdf,lock           |   *   |    *    |   N   |    N    |    N
+ ulckpwdf,unlock        |   *   |    *    |   N   |    N    |    N
+ lock?                  |   *   |    *    |   N   |    N    |    N
 
 
 4. Structure

--- a/extconf.rb
+++ b/extconf.rb
@@ -16,10 +16,10 @@ $CFLAGS = case RUBY_VERSION
 implementation = case CONFIG['host_os']
                  when /linux/i; 'shadow'
                  when /sunos|solaris/i; 'shadow'
-                 when /freebsd/i; 'pwd'
+                 when /freebsd|openbsd/i; 'pwd'
                  when /darwin/i; 'pwd'
                  else; nil
-                   "This library works on OS X, FreeBSD, Solaris and Linux."
+                   "This library works on OS X, FreeBSD, OpenBSD, Solaris and Linux."
                  end
 
 ok = true
@@ -65,5 +65,5 @@ if ok
 
   create_makefile("shadow", implementation)
 else
-  raise "You are missing some of the required functions from either shadow.h on Linux/Solaris, or pwd.h on FreeBSD/OS X."
+  raise "You are missing some of the required functions from either shadow.h on Linux/Solaris, or pwd.h on FreeBSD/OpenBSD/OS X."
 end

--- a/pwd/shadow.c
+++ b/pwd/shadow.c
@@ -1,7 +1,7 @@
 /*
  * shadow.c
  *
- * Ruby extention module for using FreeBSD/OS X pwd.h.
+ * Ruby extention module for using FreeBSD/OpenBSD/OS X pwd.h.
  *
  * Copyright (C) 1998-1999 by Takaaki.Tateishi(ttate@jaist.ac.jp)
  * License: Free for any use with your own risk!

--- a/ruby-shadow.gemspec
+++ b/ruby-shadow.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
                                 'Remi Broemeling',
                                 'Takaaki Tateishi']
 
-  spec.description           = 'This module provides access to shadow passwords on Linux, OSX, FreeBSD, and Solaris'
+  spec.description           = 'This module provides access to shadow passwords on Linux, OSX, FreeBSD, OpenBSD, and Solaris'
   spec.email                 = ['adam.palmblad@teampages.com']
   spec.extensions            = ['extconf.rb']
   spec.files                 = []


### PR DESCRIPTION
Although to be honest, the most work was updating the table in README.

Tested with Puppet 3.3.2 on OpenBSD 5.4.
