### PR TITLE
Add 'sp_loginclass' to retrieve the user's login class

### DIFF
--- a/README
+++ b/README
@@ -56,6 +56,7 @@ Shadow::Passwd::Entry (Struct::PasswdEntry)
                     considered inactive and disabled.
        sp_expire - days since Jan 1, 1970 when  account  will  be
                    disabled
+       sp_loginclass - pointer to null-terminated user login class.
 
 
 5. Description

--- a/pwd/shadow.c
+++ b/pwd/shadow.c
@@ -66,6 +66,7 @@ static VALUE convert_pw_struct( struct passwd *entry )
          INT2FIX(difftime(entry->pw_change, 0) / (24*60*60)), /* pw_change */
          INT2FIX(difftime(entry->pw_expire, 0) / (24*60*60)), /* sp_expire */
          Qnil, /* sp_flag */
+         rb_tainted_str_new2(entry->pw_class), /* sp_loginclass, user access class */
          NULL);
 }
 
@@ -107,7 +108,8 @@ Init_shadow()
                                      "sp_namp","sp_pwdp","sp_lstchg",
                                      "sp_min","sp_max","sp_warn",
                                      "sp_inact","pw_change",
-                                     "sp_expire","sp_flag", NULL);
+                                     "sp_expire","sp_flag",
+                                     "sp_loginclass", NULL);
   rb_sGroupEntry = rb_struct_define("GroupEntry",
                                     "sg_name","sg_passwd",
                                     "sg_adm","sg_mem",NULL);

--- a/shadow/shadow.c
+++ b/shadow/shadow.c
@@ -44,6 +44,7 @@ static VALUE convert_pw_struct( struct spwd *entry )
                       Qnil, /* used by BSD, pw_change, date when the password expires, in days since Jan 1, 1970 */
 		      INT2FIX(entry->sp_expire),
 		      INT2FIX(entry->sp_flag),
+		      rb_tainted_str_new2(entry->pw_class),
 		      NULL);
 };
 static VALUE
@@ -158,6 +159,7 @@ rb_shadow_putspent(VALUE self, VALUE entry, VALUE file)
   centry.sp_inact = FIX2INT(val[6]);
   centry.sp_expire = FIX2INT(val[8]);
   centry.sp_flag = FIX2INT(val[9]);
+  centry.sp_loginclass = StringValuePtr(val[10]);
 
   result = putspent(&centry,cfile);
 
@@ -243,7 +245,9 @@ Init_shadow()
   rb_sPasswdEntry = rb_struct_define("PasswdEntry",
 				     "sp_namp","sp_pwdp","sp_lstchg",
 				     "sp_min","sp_max","sp_warn",
-				     "sp_inact", "pw_change", "sp_expire","sp_flag", NULL);
+				     "sp_inact", "pw_change",
+				     "sp_expire","sp_flag",
+				     "sp_loginclass", NULL);
   rb_sGroupEntry = rb_struct_define("GroupEntry",
 				    "sg_name","sg_passwd",
 				    "sg_adm","sg_mem",NULL);


### PR DESCRIPTION
This was developed and tested on OpenBSD, though I've not yet been able to verify this on other systems.

``` ruby
irb(main):001:0> require 'shadow'
=> true
irb(main):002:0> Shadow::Passwd.getspnam('jasper').sp_loginclass
=> "staff"
irb(main):003:0> 
```
