### PR TITLE
Replacing RSTRUCT_PTR with rb_ary_entry

### DIFF
--- a/shadow/shadow.c
+++ b/shadow/shadow.c
@@ -146,7 +146,7 @@ rb_shadow_putspent(VALUE self, VALUE entry, VALUE file)
     rb_raise(rb_eTypeError,"argument must be a File.");
 
   for(i=0; i<NUM_FIELDS; i++)
-    val[i] = RSTRUCT_PTR( entry )[i]; //val[i] = RSTRUCT(entry)->ptr[i];
+    val[i] = rb_ary_entry(entry, i); //val[i] = RSTRUCT(entry)->ptr[i];
   cfile = file_ptr( RFILE(file)->fptr );
 
 


### PR DESCRIPTION
Replacing RSTRUCT_PTR Macro with rb_ary_entry for array access

This was suggested as a fix here:
https://github.com/rubinius/rubinius/issues/3326

It is to fix this issue:
https://github.com/apalmblad/ruby-shadow/issues/21

I tested making this on OS X and linux with ruby-2.1 (2.2 on linux) and rubinius 2.5. Both compiled successfully.

I am not sure how to test this library for this change. I was hoping you could provide assistance with this. Thank you.

