### PR TITLE
extconf.rb: use Rbconfig::CONFIG instead of mkmf CONFIG

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -14,7 +14,7 @@ $CFLAGS = case RUBY_VERSION
           else; ''
           end
 
-implementation = case CONFIG['host_os']
+implementation = case RbConfig::CONFIG['host_os']
                  when /linux/i; 'shadow'
                  when /sunos|solaris/i; 'shadow'
                  when /freebsd|mirbsd|netbsd|openbsd/i; 'pwd'


### PR DESCRIPTION
In mkmf.rb CONFIG is defined as CONFIG is defined as RbConfig::MAKEFILE_CONFIG and RbConfig::MAKEFILE_CONFIG is almost same as RbConfig::CONFIG except that RbConfig::MAKEFILE_CONFIG uses reference for other variables.

Using CONFIG in extconf.rb causes error with ruby3.2 because now CONFIG['host_os'] uses reference for target_os variable, and extconf.rb expects that this variable is all expanded. So instead, use RbConfig::CONFIG .

Closes #30