### PR TITLE
Fix extension not building on Ruby 3.2

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -14,7 +14,7 @@ $CFLAGS = case RUBY_VERSION
           else; ''
           end
 
-implementation = case CONFIG['host_os']
+implementation = case RbConfig::CONFIG['host_os']
                  when /linux/i; 'shadow'
                  when /sunos|solaris/i; 'shadow'
                  when /freebsd|mirbsd|netbsd|openbsd/i; 'pwd'


### PR DESCRIPTION
In Ruby 3.2 it appears `CONFIG['host_os']` resolves to `$(target_os)`. Use `RbConfig::CONFIG` instead of `CONFIG`.